### PR TITLE
Change project looking for from purge to memcache

### DIFF
--- a/Policy/memcacheEnabled.policy.yml
+++ b/Policy/memcacheEnabled.policy.yml
@@ -19,4 +19,4 @@ parameters:
   module:
     type: string
     description: The name of the module to ensure is enabled.
-    default: purge
+    default: memcache


### PR DESCRIPTION
This is to resolve issue #2. 

The policy has been modified to look for the `memcache` module now instead of the `purge` module.