### PR TITLE
Change profile to use proper kint name

### DIFF
--- a/profiles/d8_security_review.profile.yml
+++ b/profiles/d8_security_review.profile.yml
@@ -3,7 +3,7 @@ policies:
     Drupal-8:ConfigDevelDisabled:
     Drupal-8:DevelDisabled:
     Drupal-8:ErrorLevel:
-    Drupal-8:KnitDisabled:
+    Drupal-8:KintDisabled:
     Drupal-8:NoBackupAndMigrate:
     Drupal-8:NoExperimental:
     Drupal-8:PhpDisabled:


### PR DESCRIPTION
This update changes the name for the security policy to resolve the error with KnitDisabled being missing.