### PR TITLE
Docs for configuring memcache differ between PHP 5.6 and PHP 7.1

### DIFF
--- a/Policy/memcacheExtensionConfigured.policy.yml
+++ b/Policy/memcacheExtensionConfigured.policy.yml
@@ -5,8 +5,9 @@ tags:
   - Performance
 description: |
     In order for the memcache module to work, the php [memcache**d** extension](http://php.net/manual/en/book.memcached.php)
-    must be available on the runtime environment. In addition, Drupal must tell
-    the memcache module to use this extension (opposed to the memcache extension).
+    must be available on the runtime environment. In addition, when using PHP 5.6,
+    Drupal must tell the memcache module to use the  memcache**d** extension (opposed to 
+    the memcache extension).
 
 remediation: |
   Please ensure the memcached php extension is installed and the `settings.php`


### PR DESCRIPTION
This check fails for PHP 7.1 so I think it is a false positive.

<img width="965" alt="screenshot 2018-07-05 22 56 37" src="https://user-images.githubusercontent.com/10674613/42357596-b0ff1ccc-80a6-11e8-902c-ad96ecfa7fac.png">
