### PR TITLE
ModuleDisabled: Change conditional to match what core 8.5.6 returns.

### DIFF
--- a/src/Audit/ModuleDisabled.php
+++ b/src/Audit/ModuleDisabled.php
@@ -39,7 +39,7 @@ class ModuleDisabled extends Audit implements RemediableInterface {
 
     $status = strtolower($info[$module]['status']);
 
-    return ($status == 'not installed');
+    return ($status != 'enabled');
   }
 
   public function remediate(Sandbox $sandbox)


### PR DESCRIPTION
When running Drush 9.3.0 and Drupal core 8.5.6, I saw the ModuleDisabled reporting that modules which are not enabled were enabled. Looking into it, the check used by ModuleDisabled:audit is looking for a string of 'not installed' while drush calls against my stack are returning 'disabled'. It looks like core 8.4+ return 'disabled' while 8.3- return 'not installed'. 

This commit changes the conditional to instead look for status which _does not_ match 'enabled', which should work against either version of core.