### PR TITLE
Pass uid as --uid rather than default argument.

### DIFF
--- a/src/Audit/User1.php
+++ b/src/Audit/User1.php
@@ -53,8 +53,8 @@ class User1 extends Audit implements RemediableInterface {
 
     // Status.
     $status = (bool) $sandbox->getParameter('status');
-    if ($status !== (bool) $user->status) {
-      $errors[] = 'Status is not set correctly. Should be ' . ($user->status ? 'active' : 'inactive') . '.';
+    if ($status !== (bool) $user->user_status) {
+      $errors[] = 'Status is not set correctly. Should be ' . ($user->user_status ? 'active' : 'inactive') . '.';
     }
 
     $sandbox->setParameter('errors', $errors);
@@ -86,7 +86,7 @@ class User1 extends Audit implements RemediableInterface {
       return TRUE;
     }, [
       'uid' => $user->uid,
-      'status' => (int) (bool) $sandbox->getParameter('status'),
+      'user_status' => (int) (bool) $sandbox->getParameter('status'),
       'password' => $this->generateRandomString(),
       'email' => $sandbox->getParameter('email'),
       'username' => $this->generateRandomString()

--- a/src/Audit/User1.php
+++ b/src/Audit/User1.php
@@ -30,7 +30,7 @@ class User1 extends Audit implements RemediableInterface {
   public function audit(Sandbox $sandbox) {
     // Get the details for user #1.
     $user = $sandbox->drush(['format' => 'json'])
-                    ->userInformation(1);
+                    ->userInformation('--uid=1');
 
     $user = (object) array_pop($user);
 
@@ -66,7 +66,7 @@ class User1 extends Audit implements RemediableInterface {
 
     // Get the details for user #1.
     $user = $sandbox->drush(['format' => 'json'])
-                    ->userInformation(1);
+                    ->userInformation('--uid=1');
 
     $user = (object) array_pop($user);
 


### PR DESCRIPTION
Using Drush 9.3.0 and core 8.5.6, calls to the User1LockDown policy were showing an error from drush

```
 Could not determine the state of Administrator login is locked down (uid:1) due to an error:
    ```
    Drush command failed: user-information
    ```
```
Looks like newer versions of drush expect the default argument to be the username rather than uid and expect the uid to be passed using the `--uid` parameter.

```
$ drush @datasmith.local help user-information
Print information about the specified user(s).

Examples:
  drush user:information someguy,somegal            Display information about the someguy and somegal user accounts.
  drush user:information --mail=someguy@somegal.com Display information for a given email account.
  drush user:information --uid=5                    Display information for a given user id.

Arguments:
  [names] A comma delimited list of user names.

Options:
  --format[=FORMAT] Format the result data. Available formats: csv,json,list,php,print-r,sections,string,table,tsv,var_dump,var_export,xml,yaml [default: "table"]
  --uid=UID         A comma delimited list of user ids to lookup (an alternative to names).
  --mail=MAIL       A comma delimited list of emails to lookup (an alternative to names).
  --fields=FIELDS   Available fields: User ID (uid), User name (name), Password (pass), User mail (mail), User theme (theme), Signature (signature), Signature format (signature_format), User created
                    (user_created), Created (created), User last access (user_access), Last access (access), User last login (user_login), Last login (login), User status (user_status), Status
                    (status), Time zone (timezone), User picture (picture), Initial user mail (init), User roles (roles), Group Audience (group_audience), Language code (langcode), Uuid (uuid)
                    [default: "uid,name,mail,roles,user_status"]
  --field=FIELD     Select just one field, and force format to 'string'.
```