### PR TITLE
You can't install this plugin in Drutiny 2.2 anymore because http2.x-…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "drutiny/drutiny": "2.1.*@dev || 2.2.*@dev",
-        "drutiny/http": "2.x-dev",
+        "drutiny/http": "2.x-dev#2.2",
         "symfony/yaml": "^3.2"
     },
     "autoload": {


### PR DESCRIPTION
…dev requires Drutiny 2.3