### PR TITLE
Add new policy for Views UI Disabled check

### DIFF
--- a/Policy/ViewsDisabled.policy.yml
+++ b/Policy/ViewsDisabled.policy.yml
@@ -1,0 +1,18 @@
+title: Views UI module is not installed
+class: \Drutiny\Plugin\Drupal8\Audit\ModuleDisabled
+name: Drupal-8:ViewsEnabled
+tags:
+  - Drupal 8
+  - Best Practice
+  - Performance
+description: |
+  This module can impose a small performance penalty when enabled, and 
+  can allow the essential views required by your website to be modified.
+remediation: "Disable the module: `drush pm-uninstall views_ui -y`"
+success: The Views UI module is not currently enabled.
+failure: The Views UI module is currently enabled.
+parameters:
+  module:
+    type: string
+    description: The name of the module to ensure is not installed.
+    default: views_ui

--- a/Policy/viewsUIDisabled.policy.yml
+++ b/Policy/viewsUIDisabled.policy.yml
@@ -1,6 +1,6 @@
 title: Views UI module is not installed
 class: \Drutiny\Plugin\Drupal8\Audit\ModuleDisabled
-name: Drupal-8:ViewsEnabled
+name: Drupal-8:ViewsUIDisabled
 tags:
   - Drupal 8
   - Best Practice


### PR DESCRIPTION
This is a new policy to verify that the Views UI module has been disabled in Drupal 8.