### PR TITLE
Rename calls to check() to audit()

### DIFF
--- a/src/Audit/ConfigCheck.php
+++ b/src/Audit/ConfigCheck.php
@@ -61,7 +61,7 @@ class ConfigCheck extends AbstractComparison implements RemediableInterface {
     $key = $sandbox->getParameter('key');
     $value = $sandbox->getParameter('value');
     $sandbox->drush()->configSet($collection, $key, $value);
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }

--- a/src/Audit/ModuleDisabled.php
+++ b/src/Audit/ModuleDisabled.php
@@ -46,7 +46,7 @@ class ModuleDisabled extends Audit implements RemediableInterface {
   {
     $module = $sandbox->getParameter('module');
     $sandbox->drush()->pmUninstall($module, '-y');
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
 }

--- a/src/Audit/User1.php
+++ b/src/Audit/User1.php
@@ -92,7 +92,7 @@ class User1 extends Audit implements RemediableInterface {
       'username' => $this->generateRandomString()
     ]);
 
-    return $this->check($sandbox);
+    return $this->audit($sandbox);
   }
 
   /**


### PR DESCRIPTION
Accompanies change to Drutiny [Issue 217](https://www.github.com/drutiny/drutiny/issues/217).