### PR TITLE
Fix references to cron timestamp to reflect array returned in audit.

### DIFF
--- a/src/Audit/CronLast.php
+++ b/src/Audit/CronLast.php
@@ -25,9 +25,9 @@ class CronLast extends Audit {
         return FALSE;
       }
 
-      $sandbox->setParameter('cron_last', date('l jS \of F Y h:i:s A', $last));
+      $sandbox->setParameter('cron_last', date('l jS \of F Y h:i:s A', $last['system.cron_last']));
 
-      $time_diff = time() - $last;
+      $time_diff = time() - $last['system.cron_last'];
       // Fail if cron hasn't run in the last 24 hours.
       if ($time_diff > 86400) {
         return FALSE;


### PR DESCRIPTION
This PR fixes the references to the return variable, by referencing `$last['system.cron_last']` instead of `$last`, because `$last` is a keyed array which otherwise produces the following error:

```
Warning: date() expects parameter 2 to be integer, array given in /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/plugin-drupal-8/src/Audit/CronLast.php on line 34

Fatal error: Uncaught Error: Unsupported operand types in /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/plugin-drupal-8/src/Audit/CronLast.php:36
Stack trace:
#0 /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/drutiny/src/Audit.php(76): Drutiny\Plugin\Drupal8\Audit\CronLast->audit(Object(Drutiny\Sandbox\Sandbox))
#1 /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/drutiny/src/Sandbox/Sandbox.php(94): Drutiny\Audit->execute(Object(Drutiny\Sandbox\Sandbox))
#2 /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/drutiny/src/Assessment.php(58): Drutiny\Sandbox\Sandbox->run()
#3 /Users/karl/Downloads/drutiny-nightly-rework_drutiny/drutiny-nightly/x/vendor/drutiny/drutiny/src/Command/ProfileRunCommand.php(258): Drutiny\Assessment->assessTarget(Object(Drutiny\Target\DrushTarget), Array, Object(DateTime), Object(DateTime), false)
```