### PR TITLE
Replace the term blacklist with denylist

### DIFF
--- a/src/Audit/User1.php
+++ b/src/Audit/User1.php
@@ -14,7 +14,7 @@ use Drutiny\Annotation\Param;
  *  description = "The email the user account should be.",
  * )
  * @Param(
- *  name = "blacklist",
+ *  name = "denylist",
  *  description = "List of usernames that are not acceptable.",
  * )
  * @Param(
@@ -38,7 +38,7 @@ class User1 extends Audit implements RemediableInterface {
     $fixups = [];
 
     // Username.
-    $pattern = $sandbox->getParameter('blacklist');
+    $pattern = $sandbox->getParameter('denylist');
     if (preg_match("#${pattern}#i", $user->name)) {
       $errors[] = "Username '$user->name' is too easy to guess.";
     }


### PR DESCRIPTION
PR to replace the terms whitelist and blacklist with more appropriate terms based on the guidance from [https://developers.google.com/style/word-list#blacklist](https://developers.google.com/style/word-list#blacklist)